### PR TITLE
Swagger UI included as webjar, so there's a UI out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Clone this git repo and use `sbt run` to start the Akka Http server.
 
-Uses [swagger-akka-http](https://github.com/swagger-akka-http/swagger-akka-http) which is built using [swagger.io](http://swagger.io/) libs.
+Uses [swagger-akka-http](https://github.com/swagger-akka-http/swagger-akka-http) which is built using [swagger.io](http://swagger.io/) libs. UI is included as [webjar](https://github.com/webjars/swagger-ui).   
 
-Test using http://petstore.swagger.io/ and replace the swagger.json with http://localhost:12345/api-docs/swagger.json
+Test using the Swagger UI at http://localhost:12345/api-docs and by opening the swagger.json at http://localhost:12345/api-docs/swagger.json
 
-The Swagger UI can be used to send sample requests.
+The [Swagger UI](http://localhost:12345/api-docs) at  can be used to send sample requests.
 
 [Swagger 1.5/1.6 version](https://github.com/pjfanning/swagger-akka-http-sample/tree/swagger-1.5)

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,27 @@ val swaggerVersion = "2.1.11"
 
 //resolvers += Resolver.sonatypeRepo("snapshots")
 
-libraryDependencies ++= Seq(
+val swaggerDependencies = Seq(
   "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.0.0",
   "com.github.swagger-akka-http" %% "swagger-akka-http" % "2.6.0",
   "com.github.swagger-akka-http" %% "swagger-scala-module" % "2.5.0",
   "com.github.swagger-akka-http" %% "swagger-enumeratum-module" % "2.3.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+  "io.swagger.core.v3" % "swagger-jaxrs2-jakarta" % swaggerVersion
+)
+
+/**
+ * Leave out swaggerUIDependencies if you don't want to include the swaggerUI.
+ * See also SwaggerDocService
+ */
+val swaggerUIDependencies = Seq(
+  "org.webjars" % "webjars-locator" % "0.41",
+  "org.webjars" % "swagger-ui" % "3.50.0",
+)
+
+libraryDependencies ++=
+  Seq(
   "pl.iterators" %% "kebs-spray-json" % "1.9.3",
-  "io.swagger.core.v3" % "swagger-jaxrs2-jakarta" % swaggerVersion,
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
@@ -24,4 +37,5 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
   "ch.megard" %% "akka-http-cors" % "1.1.2",
   "org.slf4j" % "slf4j-simple" % "1.7.32"
-)
+)  ++ swaggerDependencies ++ swaggerUIDependencies
+

--- a/src/main/scala/com/example/akka/Rest.scala
+++ b/src/main/scala/com/example/akka/Rest.scala
@@ -23,6 +23,7 @@ object Rest extends App with RouteConcatenation {
   val add = system.actorOf(Props[AddActor])
   val addOption = system.actorOf(Props[AddOptionActor])
   val hello = system.actorOf(Props[HelloActor])
+
   val routes =
     cors() (new AddService(add).route ~
       new AddOptionService(addOption).route ~

--- a/src/main/scala/com/example/akka/swagger/SwaggerDocService.scala
+++ b/src/main/scala/com/example/akka/swagger/SwaggerDocService.scala
@@ -10,7 +10,12 @@ import com.example.akka.echolist.EchoListService
 import com.example.akka.hello.HelloService
 import io.swagger.v3.oas.models.ExternalDocumentation
 
-object SwaggerDocService extends SwaggerHttpService {
+/**
+ * Sample SwaggerDocService, replace values with those applicable your application.
+ * By default, a swagger UI is made available too on the default routes. If you don't need the UI, or want
+ * to load the UI in another way, replace [[SwaggerHttpWithUiService]] with [[com.github.swagger.akka.SwaggerHttpService]]
+ */
+object SwaggerDocService extends SwaggerHttpWithUiService {
   override val apiClasses = Set(classOf[AddService], classOf[AddOptionService], classOf[HelloService],
     EchoEnumService.getClass, EchoEnumeratumService.getClass, EchoListService.getClass)
   override val host = "localhost:12345"

--- a/src/main/scala/com/example/akka/swagger/SwaggerHttpWithUiService.scala
+++ b/src/main/scala/com/example/akka/swagger/SwaggerHttpWithUiService.scala
@@ -1,0 +1,89 @@
+package com.example.akka.swagger
+
+import akka.http.javadsl.server.Rejections
+import akka.http.scaladsl.model.StatusCodes.PermanentRedirect
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
+import akka.http.scaladsl.server.Route
+import akka.util.ByteString
+import com.example.akka.swagger.SwaggerHttpWithUiService.swaggerUi
+import com.github.swagger.akka.SwaggerHttpService
+import org.webjars.{MultipleMatchesException, NotFoundException, WebJarAssetLocator}
+
+import scala.concurrent.Future
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+
+/**
+ * SwaggerHttpService along with swagger-ui.
+ *
+ * Swagger-UI is loaded as webjar, via [[org.webjars.WebJarAssetLocator]] and served via akka-http.
+ */
+trait SwaggerHttpWithUiService extends SwaggerHttpService {
+  val webJarAssetLocator = new WebJarAssetLocator()
+
+  /**
+   * Serve files from webjar.
+   * Inspired heavily by
+   * [[https://github.com/ThoughtWorksInc/akka-http-webjars/blob/master/src/main/scala/com/thoughtworks/akka/http/WebJarsSupport.scala akka-http-webjars]] but with some
+   * changes
+   *
+   * @param webJarName
+   * @return
+   */
+  def webJars(webJarName: String, indexContent: Future[HttpEntity.Strict]): Route = {
+      concat(
+        pathEnd {
+          redirect(s"/${apiDocsPath}/", PermanentRedirect) // A missing / at the end would break all relative paths in the index.html, so redirect to /
+        },
+        pathSingleSlash {
+          complete(indexContent)
+        },
+        extractUnmatchedPath { path =>
+          Try(webJarAssetLocator.getFullPath(webJarName, path.toString)) match {
+            case Success(fullPath) =>
+              getFromResource(fullPath)
+            case Failure(_: NotFoundException) =>
+              reject
+            case Failure(e: MultipleMatchesException) =>
+              reject(Rejections.validationRejection(e.getMessage))
+            case Failure(e) => failWith(e)
+          }
+        })
+  }
+
+  /**
+   * Content of the index.html for the swagger site, based on the original one included in the
+   * [[https://github.com/webjars/swagger-ui swagger-ui webjar]].
+   *
+   * The default index [[https://github.com/swagger-api/swagger-ui/blob/master/dist/index.html index.html]] is an example for the default petstore example of Swagger,
+   The example html is turned into the page for the configured service, using poor-man's templating e.g. regexps
+   * @return
+   */
+  def swaggerIndex(classLoader: ClassLoader = _defaultClassLoader): Future[HttpEntity.Strict] = {
+    Future.fromTry(Try {
+      val fullPath = webJarAssetLocator.getFullPath(swaggerUi, "index.html")
+      val url = classLoader.getResource(fullPath)
+      /**
+       * Since the index.html from Swagger is relatively simple, we can get away with regular expressions.
+       * I wouldn't use regexp  for any generic html content.
+       */
+      val content = Source.fromURL(url).mkString
+        .replaceFirst("https://petstore.swagger.io/v2/swagger.json", s"/${apiDocsPath}/swagger.json") // Update url to the swagger file
+      HttpEntity.Strict(ContentTypes.`text/html(UTF-8)`, ByteString(content))
+    })
+  }
+
+  val swaggerUiRoute = {
+    pathPrefix(apiDocsPath) {
+       webJars(swaggerUi, swaggerIndex())
+    }
+  }
+
+  override val routes = super.routes ~ swaggerUiRoute
+}
+
+object SwaggerHttpWithUiService {
+  val swaggerUi = "swagger-ui" // Name of the webjar
+}
+
+


### PR DESCRIPTION
The swagger UI is available in the example. I've extended the example to serve the swagger ui as webjar, so people have a fully working uit out-of-the-box example.

The default index.html that's included in the [swagger-ui-webjar](https://github.com/webjars/swagger-ui) contains a reference to a hardcoded url, that's updated using a regular expression.

If you want you can include this in the example, or maybe add this as an extra example
Some of the code might be reusable and the functionality to offer a ui out-of-the-box in the main library might viable, but I'd have to do some more design thinking about that.